### PR TITLE
GHC 9.0.1 support

### DIFF
--- a/chr-core/src/CHR/Types/Core.hs
+++ b/chr-core/src/CHR/Types/Core.hs
@@ -425,8 +425,10 @@ chrmatcherUnlift mtch menv s = do
 -- | Lift into CHRMatcher
 chrmatcherLift :: (LookupApply subst subst) => (subst -> Maybe subst) -> CHRMatcher subst ()
 chrmatcherLift f = do
-    [sl,sg] <- fmap Lk.unlifts $ getl chrmatcherstateVarLookup -- gets (unStackedVarLookup . _chrmatcherstateVarLookup)
-    maybe chrMatchFail (\snew -> chrmatcherstateVarLookup =$: (Lk.apply snew)) $ f sg
+    s <- fmap Lk.unlifts $ getl chrmatcherstateVarLookup -- gets (unStackedVarLookup . _chrmatcherstateVarLookup)
+    case s of
+      [sl, sg] -> maybe chrMatchFail (\snew -> chrmatcherstateVarLookup =$: (Lk.apply snew)) $ f sg
+      _ -> error "chrmatcherLift expects exactly two elements in the varlookup stack."
 
 -- | Run a CHRMatcher
 chrmatcherRun' :: (CHREmptySubstitution subst) => (CHRMatcherFailure -> r) -> (subst -> CHRWaitForVarSet subst -> x -> r) -> CHRMatcher subst x -> CHRMatchEnv (VarLookupKey subst) -> StackedVarLookup subst -> r

--- a/chr-data/src/CHR/Data/Lens/MicroLens.hs
+++ b/chr-data/src/CHR/Data/Lens/MicroLens.hs
@@ -91,19 +91,19 @@ a ^. f = get f a
 
 -- | Alias for 'get' to avoid conflict with state get; not happy choice because of 'getl'
 getL :: (f :-> a) -> f -> a
-getL = flip (^.)
+getL = \x y -> y ^. x
 {-# INLINE getL #-}
 
 infixr 4 ^=
 -- | functional setter, which acts like a field assigner
 (^=) :: (a :-> b) -> b -> a -> a
-(^=) = set
+(^=) = \x y -> set x y
 {-# INLINE (^=) #-}
 
 infixr 4 ^$=
 -- | functional modify
 (^$=) :: (a :-> b) -> (b -> b) -> a -> a
-(^$=) = over
+(^$=) = \x f -> over x f
 {-# INLINE (^$=) #-}
 
 {-
@@ -126,18 +126,18 @@ modifyAndGet = (=$^:)
 
 -- | monadic get
 getl :: MS.MonadState f m => (f :-> o) -> m o
-getl = use
+getl = \x -> use x
 
 infixr 4 =:
 -- | monadic set
 (=:) :: MS.MonadState f m => (f :-> o) -> o -> m ()
-(=:) = (.=)
+(=:) = \x y -> x .= y
 {-# INLINE (=:) #-}
 
 infixr 4 =$:
 -- | monadic modify & set
 (=$:) :: MS.MonadState f m => (f :-> o) -> (o -> o) -> m ()
-(=$:) = modifying
+(=$:) = \x f -> modifying x f
 {-# INLINE (=$:) #-}
 
 {-


### PR DESCRIPTION
I don't actually know why chrmatcherLift expects exactly two elements in the varlookup stack, but this should get exactly the same behavior as before the MonadFail changes except for the custom error message.

I can compile this with GHC 8.10.4 with the following `cabal.project` file in the top-level directory of this repo:

```
packages: chr-*

source-repository-package
    type: git
    location: https://github.com/noughtmare/logict-state.git
    tag: a56340e0a88bafc72b17939d66dccead490a5bb2
```

It requires the `logict-state` changes from this pull request: https://github.com/atzedijkstra/logict-state/pull/3.